### PR TITLE
expose route deletion and resolve function changed to be optional

### DIFF
--- a/v2/interfaces.go
+++ b/v2/interfaces.go
@@ -5,19 +5,21 @@ import "context"
 type (
 	// CmdParser parses the content of a Discord message into a string slice.
 	//
-	// Optionally implemented by Commander
+	// Optionally implemented by Handler
 	CmdParser interface {
 		Parse(string) ([]string, error)
 	}
 
 	// handlerFunc executes when a root route is invoked.
 	// A root route is any route that is added to the router via Has
+	//
+	// Not to be confused with Handler. handlerFunc calls the proper Handler given a command.
 	handlerFunc func(ctx context.Context)
 
 	// Middlewarer allows execution of a handler before Handle is executed.
 	//
 	// Do accepts a context and returns an error. If error is nil, will execute the next Middlewarer or Handle.
-	// Otherwise, it will enter the Resolve function.
+	// Otherwise, it will enter the Resolve function (if implemented)
 	//
 	// Context mutated from within a middleware will only persist within scope.
 	Middlewarer interface {
@@ -34,17 +36,21 @@ type (
 		Default() string
 	}
 
-	// Commander is used by a route to handle Discord's Message Create events.
+	// Handler is bound to a route and will be called when handling Discord's Message Create events.
 	// https://discord.com/developers/docs/topics/gateway#message-create
 	//
-	// Can optionally implement CmdParser, but is not required.
+	// Can optionally implement CmdParser and Resolver, but is not required.
 	//
-	// Handle is where a command's business logic should belong.
-	//
-	// Resolve is where an error in ctx.Err can be handled, along with any other necessary cleanup.
-	// It is run if (custom) parsing fails, middleware fails, or if Handle fails.
-	Commander interface {
+	// If Handler does not implement Resolver, any returned error will be ignored.
+	Handler interface {
 		Handle(ctx context.Context) error
+	}
+
+	// Resolver is an optional interface that can be satisfied by a command.
+	// It is used for handling any errors returned from Handler.
+	//
+	// Optionally implemented by Handler
+	Resolver interface {
 		Resolve(ctx context.Context)
 	}
 )

--- a/v2/route.go
+++ b/v2/route.go
@@ -1,26 +1,33 @@
 package v2
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pixeltopic/sayori/v2/utils"
-
-	"context"
 )
 
 var cmdParserDefault = strings.Fields
 
-// handleParse checks if an event implements Parseable; if it does, runs Parseable. Else, runs default parser
-func handleParse(c Commander, content string) ([]string, error) {
+// handleParse checks if an event implements CmdParser; if it does, runs CmdParser. Else, runs default parser
+func handleParse(h Handler, content string) ([]string, error) {
 	var (
 		p  CmdParser
 		ok bool
 	)
-	if p, ok = c.(CmdParser); !ok {
+	if p, ok = h.(CmdParser); !ok {
 		return cmdParserDefault(content), nil
 	}
 
 	return p.Parse(content)
+}
+
+// handleResolve returns the Resolve func if Handler implements Resolver. Otherwise returns a Resolve func stub.
+func handleResolve(h Handler) func(ctx context.Context) {
+	if r, ok := h.(Resolver); ok {
+		return r.Resolve
+	}
+	return func(_ context.Context) {}
 }
 
 // handleMiddlewares runs each middleware in order until completion.
@@ -61,7 +68,7 @@ func trimPrefix(command, prefix string) (string, bool) {
 //
 // Routes can be modified after they are added to the router, and are not goroutine safe.
 type Route struct {
-	c           Commander
+	h           Handler
 	p           Prefixer
 	aliases     []string
 	subroutes   []*Route
@@ -139,17 +146,17 @@ func (r *Route) Use(middlewares ...Middlewarer) *Route {
 	return r
 }
 
-// Do the execution of a Commander implementation when there is a Message Create event.
+// Do execution of the provided Handler when there is a Message Create event.
 // https://discord.com/developers/docs/topics/gateway#message-create
 //
 // A Commander can optionally implement CmdParser for custom parsing of message content.
-// Parsing errors will be handled by Resolve.
+// Handling errors and cleanup of other resources will be handled by Resolve if Resolver is implemented, otherwise skipped.
 //
-// No-ops if Commander is nil.
+// No-ops if Handler is nil.
 //
 // If Do is called multiple times, the previous Do call will be overwritten.
-func (r *Route) Do(c Commander) *Route {
-	r.c = c
+func (r *Route) Do(h Handler) *Route {
+	r.h = h
 	return r
 }
 
@@ -180,7 +187,7 @@ func createHandlerFunc(route *Route) handlerFunc {
 	if route == nil {
 		return nil
 	}
-	if route.c == nil {
+	if route.h == nil {
 		return nil
 	}
 
@@ -197,10 +204,10 @@ func createHandlerFunc(route *Route) handlerFunc {
 			return
 		}
 
-		args, err := handleParse(route.c, cmd)
+		args, err := handleParse(route.h, cmd)
 		if err != nil {
 			ctx = utils.WithErr(ctx, err)
-			route.c.Resolve(ctx)
+			handleResolve(route.h)(ctx)
 			return
 		}
 
@@ -214,16 +221,16 @@ func createHandlerFunc(route *Route) handlerFunc {
 
 		if err = handleMiddlewares(ctx, route.middlewares); err != nil {
 			ctx = utils.WithErr(ctx, err)
-			route.c.Resolve(ctx)
+			handleResolve(route.h)(ctx)
 			return
 		}
 
-		err = route.c.Handle(ctx)
+		err = route.h.Handle(ctx)
 		if err != nil {
 			ctx = utils.WithErr(ctx, err)
 		}
 
-		route.c.Resolve(ctx)
+		handleResolve(route.h)(ctx)
 
 	}
 }

--- a/v2/route.go
+++ b/v2/route.go
@@ -57,7 +57,9 @@ func trimPrefix(command, prefix string) (string, bool) {
 
 }
 
-// Route represents a command.
+// Route represents a command which consumes a DiscordGo MessageCreate event under the hood.
+//
+// Routes can be modified after they are added to the router, and are not goroutine safe.
 type Route struct {
 	c           Commander
 	p           Prefixer


### PR DESCRIPTION
If `Handle` returns an error, the error will be ignored if there is no `Resolve`.