### PR TITLE
recursive algorithm to look up newest subroute or deepest match

### DIFF
--- a/v2/route.go
+++ b/v2/route.go
@@ -293,7 +293,6 @@ func findRoute(route *Route, args []string) (*Route, int) {
 //
 // initial depth MUST be 1
 func findRouteRecursive(route *Route, args []string, depth int) (*Route, int) {
-	//fmt.Println("recursive call for depth=", depth)
 	if depth <= 0 {
 		return nil, 0
 	}
@@ -313,23 +312,25 @@ func findRouteRecursive(route *Route, args []string, depth int) (*Route, int) {
 	}
 
 	var (
-		newRoute *Route
-		newDepth int
+		newRoute             *Route
+		newDepth, finalDepth int
 	)
 
 	if depth < len(args) {
 		for _, sr := range route.FindAllSubroutes(args[depth]) {
-			//fmt.Println("loopy=", i, " depth=", depth)
-			//fmt.Println("subroute aliases=", sr.aliases)
 			newRoute, newDepth = findRouteRecursive(sr, args, depth+1)
+
+			// depth check prevents shallower subroutes from overwriting a better match.
+			// <= will prioritize most recently added subroutes while < will prioritize least recently added
+			if finalDepth <= newDepth && newRoute != nil {
+				route, finalDepth = newRoute, newDepth
+			}
 		}
 	}
-	// depth check prevents shallower subroutes from overwriting a better match.
-	// <= will prioritize most recently added subroutes while < will prioritize least recently added
-	if depth <= newDepth && newRoute != nil {
-		route, depth = newRoute, newDepth
-		//fmt.Println(newRoute.aliases)
+
+	if finalDepth == 0 {
+		finalDepth = depth
 	}
 
-	return route, depth
+	return route, finalDepth
 }

--- a/v2/route.go
+++ b/v2/route.go
@@ -311,14 +311,11 @@ func findRouteRecursive(route *Route, args []string, depth int) (*Route, int) {
 		return nil, depth - 1
 	}
 
-	var (
-		newRoute             *Route
-		newDepth, finalDepth int
-	)
+	finalDepth := depth // finalDepth is a temp variable so depth does not get reassigned, invalidating subsequent iterations
 
 	if depth < len(args) {
 		for _, sr := range route.FindAllSubroutes(args[depth]) {
-			newRoute, newDepth = findRouteRecursive(sr, args, depth+1)
+			newRoute, newDepth := findRouteRecursive(sr, args, depth+1)
 
 			// depth check prevents shallower subroutes from overwriting a better match.
 			// <= will prioritize most recently added subroutes while < will prioritize least recently added
@@ -326,10 +323,6 @@ func findRouteRecursive(route *Route, args []string, depth int) (*Route, int) {
 				route, finalDepth = newRoute, newDepth
 			}
 		}
-	}
-
-	if finalDepth == 0 {
-		finalDepth = depth
 	}
 
 	return route, finalDepth

--- a/v2/route.go
+++ b/v2/route.go
@@ -75,8 +75,9 @@ type Route struct {
 	middlewares []Middlewarer
 }
 
-// IsDefault returns true if a route will always be executed when Discord produces a Message Create event
-// with respect to the Prefixer (if provided).
+// IsDefault returns true if a route has no aliases assigned.
+// If the route has no Prefixer bound and IsDefault returns true, the Handler will
+// always be executed when Discord produces a DiscordGo MessageCreate event.
 //
 // https://discord.com/developers/docs/topics/gateway#message-create
 //
@@ -137,6 +138,8 @@ func (r *Route) getGuildPrefix(guildID string) string {
 
 // On adds new identifiers for a Route.
 // By default, aliases with whitespaces will not be matched unless a Commander also implements the CmdParser interface
+//
+// If a subroute returns true with IsDefault, it will be auto-selected when searching for the proper route.
 func (r *Route) On(aliases ...string) *Route {
 	r.aliases = append(r.aliases, aliases...)
 	return r
@@ -178,6 +181,15 @@ func (r *Route) Do(h Handler) *Route {
 func NewRoute(p Prefixer) *Route {
 	return &Route{
 		p:           p,
+		aliases:     []string{},
+		subroutes:   []*Route{},
+		middlewares: []Middlewarer{},
+	}
+}
+
+// NewSubroute returns a new Route without a Prefixer. Is equivalent to NewRoute(nil).
+func NewSubroute() *Route {
+	return &Route{
 		aliases:     []string{},
 		subroutes:   []*Route{},
 		middlewares: []Middlewarer{},

--- a/v2/route_test.go
+++ b/v2/route_test.go
@@ -120,6 +120,14 @@ func TestRoute_createHandlerFunc(t *testing.T) {
 			aliasTree: []string{"root", "sub1", "sub1", "subsub1", "subsub2"},
 			subCases: []subCase{
 				{
+					name:           "alias tiebreak will result in most recently added route being selected",
+					content:        "root sub1",
+					expectedDepth:  2,
+					expectedPrefix: "",
+					expectedErr:    nil,
+					expectedCmdID:  2,
+				},
+				{
 					name:           "common aliases shared between routes in the same depth should properly route to the correct subroute",
 					content:        "root sub1 subsub2 sub2 arg1 arg2",
 					expectedDepth:  3,

--- a/v2/route_test.go
+++ b/v2/route_test.go
@@ -1,14 +1,13 @@
 package v2
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/pixeltopic/sayori/v2/utils"
-
-	"context"
 )
 
 func makeMockMsg(content string) *discordgo.MessageCreate {
@@ -382,49 +381,4 @@ func TestRoute_createHandlerFunc(t *testing.T) {
 		}
 	}
 
-}
-
-// TODO: table driven test where messages are in a slice and we have one big testRouteDefns to test?
-// In addition we can test multiple testRouteDefns too
-// Need to find a good way to store expected test results
-func TestRoute(t *testing.T) {
-	testTrees := []*testParams{}
-
-	for _, tt := range testTrees {
-		for _, io := range tt.testIOParams {
-			t.Run("test handler func", func(t *testing.T) {
-				rr := tt.createRouteWithTestIOParams(io, t)
-				ctx := context.Background()
-				msgCreate, err := io.createMockMsg()
-				if err != nil {
-					t.FailNow()
-				}
-
-				ses, err := io.createMockSes()
-				if err != nil {
-					t.FailNow()
-				}
-
-				createHandlerFunc(rr)(utils.WithSes(utils.WithMsg(ctx, msgCreate.Message), ses))
-			})
-
-			t.Run("test that all aliases in the route tree are present", func(t *testing.T) {
-				rr := tt.createRoute()
-				found := testGetAllAliasRecursively(rr)
-				if !strSliceEqual(io.expectedAliasTree, found, true) {
-					t.Errorf("expected alias tree to be equal; got %v, want %v", found, io.expectedAliasTree)
-				}
-			})
-			t.Run("test findRoute algorithm", func(t *testing.T) {
-				rr := tt.createRoute()
-				found, depth := findRouteRecursive(rr, io.msgContentTokenized, 1)
-				if depth != io.expectedDepth {
-					t.Errorf("got %d, want %d", depth, io.expectedDepth)
-				}
-				if found == nil && io.expectedDepth != 0 {
-					t.Error("expected non-nil route")
-				}
-			})
-		}
-	}
 }

--- a/v2/util_test.go
+++ b/v2/util_test.go
@@ -106,14 +106,14 @@ func (p *testIOParams) createCmd(t *testing.T) *testCmd {
 		}
 
 		if p.expectedDepth != len(cmd.Alias) {
-			t.Error("expected depth to equal length of context alias")
+			t.Errorf("expected depth (%d) to equal length of context alias (%d)", p.expectedDepth, len(cmd.Alias))
 		}
 
 		if !strSliceEqual(p.expectedAlias, cmd.Alias, false) {
-			t.Error("expected alias to be equal")
+			t.Errorf("expected alias %v to be equal to %v", p.expectedAlias, cmd.Alias)
 		}
 		if !strSliceEqual(p.expectedArgs, cmd.Args, false) {
-			t.Error("expected args to be equal")
+			t.Errorf("expected args %v to be equal %v", p.expectedArgs, cmd.Args)
 		}
 	}
 	handleCB := func(ctx context.Context) error {


### PR DESCRIPTION
Routing now works by considering the entire subroute/command tree.

Performance was not measured, but should be able to handle simultaneous requests as long as the call stack size can accommodate for it. Realistically this case should not be hit unless traffic is unusually high and/or the command tree is deeply nested.

Table driven tests were rewritten to be more legible and to allow pinpointing of the precise handler that ran. This was necessary to test the new algorithm.